### PR TITLE
[FreshEyes] test: fix RPC coverage check

### DIFF
--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -14,6 +14,9 @@ from test_framework.test_framework import BitcoinTestFramework
 class CreateCache(BitcoinTestFramework):
     # Test network and test nodes are not required:
 
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
     def set_test_params(self):
         self.num_nodes = 0
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -829,7 +829,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                     cache_node_dir,
                     chain=self.chain,
                     extra_conf=["bind=127.0.0.1"],
-                    extra_args=['-disablewallet'],
+                    extra_args=[],
                     rpchost=None,
                     timewait=self.rpc_timeout,
                     timeout_factor=self.options.timeout_factor,

--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -144,6 +144,10 @@ class TransactionTimeRescanTest(BitcoinTestFramework):
         restorewo_wallet.importaddress(wo2, rescan=False)
         restorewo_wallet.importaddress(wo3, rescan=False)
 
+        self.log.info('Testing abortrescan when no rescan is in progress')
+        assert_equal(restorewo_wallet.getwalletinfo()['scanning'], False)
+        assert_equal(restorewo_wallet.abortrescan(), False)
+
         # check user has 0 balance and no transactions
         assert_equal(restorewo_wallet.getbalance(), 0)
         assert_equal(len(restorewo_wallet.listtransactions()), 0)


### PR DESCRIPTION
The author **BrandonOdiwuor** wrote the following PR called **test: fix RPC coverage check**, issue number **29387** in **bitcoin/bitcoin** cloned by FreshEyes below:

Fixes `https://github.com/bitcoin/bitcoin/issues/27593`

Currently, the RPC coverage check in functional tests doesn't include a list of all RPCs. This fix enables wallet RPCs to be included in the `rpc_interface.txt` used in the coverage check

This PR Reverses part of the changes on PR `https://github.com/bitcoin/bitcoin/pull/16042` - Commit `https://github.com/bitcoin/bitcoin/pull/16042/commits/fa473303972b7dad600d949dc9b303d8136cb7e7#diff-4a04bc0b355c780033960e8c261ee9b6d3c452897e1dcd88a15d272512266c76R486` to speed up cache_creation by disabling the wallet

### Update:
- I have added basic `abortrescan` RPC test (commit - eb085603af2a5da954cf7f95c7f77e173585e878) to fix the failing CI due to no coverage